### PR TITLE
Fix bower.json meta

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "cetar laundry",
+  "name": "cetar-laundry",
   "homepage": "https://github.com/Tatalazy/cetarlaundry",
   "authors": [
     "Shinta Saptarini <saptarinishinta@gmail.com>"


### PR DESCRIPTION
Ada warning seperti ini.

```
bower                     invalid-meta for:/Users/mul14/cetarlaundry/bower.json
bower                     invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes
```

Spesifikasi `bower.json` khususnya `name` bisa dilihat di https://github.com/bower/spec/blob/master/json.md#name